### PR TITLE
I improved the german translations.

### DIFF
--- a/src/app/components/Main.js
+++ b/src/app/components/Main.js
@@ -45,7 +45,7 @@ var EmptyRow = React.createClass({
             'it': ["Oops! Spiacenti, non ce l'abbiamo ancora.", 'Vuoi aiutarci? Scrivici a'],
             'es': ["", ''],
             'fr': ["Oops! Desolés, on l'a pas encore.", 'Tu veux nous aider? Ecris à'],
-            'de': ["", '']
+            'de': ["Ups! Leider haben wir das noch nicht!", 'Willst du uns helfen? Schreib uns an']
         };
         var lang = this.props.locales[0],
             message = messagesAll[lang] || messagesAll['en'];
@@ -70,7 +70,7 @@ var EmbedWikipedia = React.createClass({
             'it': 'No altre info',
             'es': 'No hay más info',
             'fr': "Pas d'autre info",
-            'de': 'Keine weitere Info'
+            'de': 'Keine weiteren Infos'
             // 'en': 'no info', 
             // 'it': 'no info',
             // 'es': 'no hay info',
@@ -163,8 +163,8 @@ var SearchBar = React.createClass({
                 description: 'Ingrédients pour le moment, plats à bientôt.'
             },
             'de': {
-                placeholder: 'Gibst eine Zutat',
-                legend: ['Gluten-free (glutenfrei)', 'Has gluten (könnte Gluten haben)'],
+                placeholder: 'Gib eine Zutat ein',
+                legend: ['Glutenfrei (glutenfrei)', 'enthält Gluten (oder könnte es enthalten)'],
                 description: ''
             }
         };

--- a/src/app/pages/Home.js
+++ b/src/app/pages/Home.js
@@ -48,7 +48,7 @@ var Index = module.exports = React.createClass({
         'Fait avec ♥ et sans gluten.'
       ],
       'de': [
-        'Gebildet mit ♥ und ohne Gluten.'
+        'Mit ♥ gemacht und ohne Gluten.'
       ]
     };
     var lang = this.props.locales[0],


### PR DESCRIPTION
Hi! I saw your project on hackernews and decided to improve the German translations really quick.

I didn't find the title tag and the Ingrident categories.

Title would be:
HatGluten - schnelle und genaue Liste mit glutenfreien Zutaten

The ingridient categories should be easy to look up on dict.leo.org

Beans, Pulses & Legumes = Bohnen & Hülsenfrüchte 
(I can't find out the difference between pulses and legumes)

Dairy & Cheese= Milchprodukte & Käse
Beverages = Getränke
Fish, Poultry & Meat =  Fisch, Geflügel & Fleisch
Fruits = Früchte
Condiments = Tischwürze
Herbs & Spices = Kräuter & Gewürze

You could register hatgluten dot whatever btw.
The project is a cool idea. My grandmother was allergic to gluten and I might be too, 
so I appreciate useful projects like this one.

Autodetection of language might also be good. Not sure if you already have it.
